### PR TITLE
Implement backward slicer and LLM characterizer

### DIFF
--- a/Model/characterizer.py
+++ b/Model/characterizer.py
@@ -9,23 +9,67 @@ structured prediction:
       payload_class: shell-exec|deserialize|jit-write|fnptr-overwrite|other,
       why: "short justification quoting the lifted IR" }
 
-Supported backends:
-  - Ollama (local) — e.g. Qwen2.5-Coder-7B-Instruct
-  - Google AI Studio — Gemini family
-  - Groq — Llama 3.x family
+Supported backends (no third-party HTTP library required; stdlib
+``urllib`` is enough):
+
+  - Ollama (local) — POSTs to ``http://localhost:11434/api/generate``
+    with ``format=json``.
+  - Google AI Studio — ``generativelanguage.googleapis.com/v1beta``
+    with ``responseMimeType=application/json``.
+  - Groq — OpenAI-compatible chat endpoint with
+    ``response_format=json_object``.
+
+Environment-variable configuration:
+
+  ===================  ==========================================
+  Variable             Meaning
+  ===================  ==========================================
+  ``LOGICTRAP_LLM``    backend name (``ollama``|``gemini``|``groq``)
+  ``LOGICTRAP_MODEL``  model name override (otherwise per-backend default)
+  ``GOOGLE_API_KEY``   required for ``gemini``
+  ``GROQ_API_KEY``     required for ``groq``
+  ``OLLAMA_URL``       Ollama base URL (default ``http://localhost:11434``)
+  ===================  ==========================================
 """
+import json
+import logging
+import os
+import re
+import urllib.error
+import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+
+log = logging.getLogger(__name__)
+
 
 GATE_KINDS = ("env", "time", "crypto", "process", "fs", "net", "hw", "locale", "mixed")
 BYPASS_DIFFICULTIES = ("trivial", "env-controllable", "fuzz-solvable", "crypto-hard", "unknown")
 PAYLOAD_CLASSES = ("shell-exec", "deserialize", "jit-write", "fnptr-overwrite", "other")
 
+SUPPORTED_BACKENDS = ("ollama", "gemini", "groq")
+
+DEFAULT_MODELS = {
+    "ollama": "qwen2.5-coder:7b",
+    "gemini": "gemini-2.0-flash",
+    "groq": "llama-3.3-70b-versatile",
+}
+
+BACKEND_KEY_ENV = {
+    "ollama": None,
+    "gemini": "GOOGLE_API_KEY",
+    "groq": "GROQ_API_KEY",
+}
+
+
+class CharacterizerError(Exception):
+    """Raised on configuration or transport failures."""
+
 
 @dataclass
 class GateCharacterization:
     gate_addr: int
-    gate_kind: str = "unknown"
+    gate_kind: str = "mixed"
     external_deps: List[str] = field(default_factory=list)
     bypass_difficulty: str = "unknown"
     payload_class: str = "other"
@@ -35,9 +79,232 @@ class GateCharacterization:
 
 
 class Characterizer:
-    def __init__(self, backend: str = "ollama", model_name: str = "qwen2.5-coder:7b"):
-        self.backend = backend
-        self.model_name = model_name
+    def __init__(
+        self,
+        backend: Optional[str] = None,
+        model_name: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: int = 120,
+        ollama_url: Optional[str] = None,
+    ):
+        resolved_backend = (backend or os.environ.get("LOGICTRAP_LLM") or "ollama").lower()
+        if resolved_backend not in SUPPORTED_BACKENDS:
+            raise CharacterizerError(
+                f"unknown backend {resolved_backend!r}; choose one of {SUPPORTED_BACKENDS}"
+            )
+        self.backend = resolved_backend
 
+        self.model_name = (
+            model_name
+            or os.environ.get("LOGICTRAP_MODEL")
+            or DEFAULT_MODELS[self.backend]
+        )
+
+        key_env = BACKEND_KEY_ENV.get(self.backend)
+        self.api_key = api_key or (os.environ.get(key_env) if key_env else None)
+        if key_env and not self.api_key:
+            raise CharacterizerError(
+                f"backend {self.backend!r} requires environment variable {key_env}"
+            )
+
+        self.timeout = int(timeout)
+        self.ollama_url = (
+            ollama_url
+            or os.environ.get("OLLAMA_URL")
+            or "http://localhost:11434"
+        ).rstrip("/")
+
+    # ------------------------------------------------------------------ #
+    # public entry point
+    # ------------------------------------------------------------------ #
     def characterize(self, gate_slice) -> GateCharacterization:
-        raise NotImplementedError
+        prompt = self._build_prompt(gate_slice)
+        raw_text = self._call_llm(prompt)
+        parsed = self._parse_response(raw_text)
+        return GateCharacterization(
+            gate_addr=getattr(gate_slice, "gate_addr", 0),
+            gate_kind=parsed["gate_kind"],
+            external_deps=parsed["external_deps"],
+            bypass_difficulty=parsed["bypass_difficulty"],
+            payload_class=parsed["payload_class"],
+            why=parsed["why"],
+            model=self.model_name,
+            raw_response=parsed,
+        )
+
+    # ------------------------------------------------------------------ #
+    # prompt building
+    # ------------------------------------------------------------------ #
+    def _build_prompt(self, gate_slice) -> str:
+        external_calls = getattr(gate_slice, "external_calls", []) or []
+        if external_calls:
+            ec_lines = []
+            for ec in external_calls:
+                target = getattr(ec, "target_name", "?")
+                addr = hex(getattr(ec, "addr", 0))
+                args = getattr(ec, "args", []) or []
+                arg_text = f"({', '.join(args)})" if args else "(...)"
+                ec_lines.append(f"  - {addr}: {target}{arg_text}")
+            external_section = "\n".join(ec_lines)
+        else:
+            external_section = "  (none detected)"
+
+        pseudo = getattr(gate_slice, "pseudo_c", "") or getattr(gate_slice, "vex_ir", "")
+        if not pseudo:
+            pseudo = "(no decompilation available)"
+
+        gate_addr = hex(getattr(gate_slice, "gate_addr", 0))
+        sink_addr = hex(getattr(gate_slice, "sink_addr", 0))
+
+        return (
+            "You are analyzing a basic block from a compiled binary that\n"
+            "guards a dangerous sink. Characterize the gate.\n\n"
+            f"GATE ADDRESS:   {gate_addr}\n"
+            f"SINK ADDRESS:   {sink_addr}\n\n"
+            "EXTERNAL CALLS IN THE SLICE:\n"
+            f"{external_section}\n\n"
+            "PSEUDO-C / IR OF THE PREDICATE:\n"
+            f"{pseudo}\n\n"
+            "Respond with a single JSON object (no other text, no markdown\n"
+            "fences) matching this schema exactly:\n\n"
+            "{\n"
+            f'  "gate_kind":         one of {list(GATE_KINDS)},\n'
+            '  "external_deps":     array of strings naming the dependencies,\n'
+            f'  "bypass_difficulty": one of {list(BYPASS_DIFFICULTIES)},\n'
+            f'  "payload_class":    one of {list(PAYLOAD_CLASSES)},\n'
+            '  "why":              short justification (<= 200 chars)\n'
+            "}\n\n"
+            "Guidance:\n"
+            '- If the predicate verifies a cryptographic signature, set\n'
+            '  bypass_difficulty to "crypto-hard".\n'
+            '- If the predicate depends on a single environment variable\n'
+            '  that an attacker can set, choose "env-controllable".\n'
+            '- If a fuzzer would plausibly solve it in seconds, choose\n'
+            '  "fuzz-solvable".\n'
+            '- If you genuinely cannot tell, set bypass_difficulty to\n'
+            '  "unknown" rather than guessing.\n'
+        )
+
+    # ------------------------------------------------------------------ #
+    # backend dispatch
+    # ------------------------------------------------------------------ #
+    def _call_llm(self, prompt: str) -> str:
+        if self.backend == "ollama":
+            return self._call_ollama(prompt)
+        if self.backend == "gemini":
+            return self._call_gemini(prompt)
+        if self.backend == "groq":
+            return self._call_groq(prompt)
+        # Should be unreachable thanks to __init__ validation.
+        raise CharacterizerError(f"unsupported backend {self.backend!r}")
+
+    def _http_post_json(self, url: str, payload: Dict[str, Any], headers: Dict[str, str]) -> Dict[str, Any]:
+        data = json.dumps(payload).encode("utf-8")
+        req_headers = {"Content-Type": "application/json", **headers}
+        req = urllib.request.Request(url, data=data, headers=req_headers)
+        try:
+            with urllib.request.urlopen(req, timeout=self.timeout) as resp:
+                body = resp.read()
+        except urllib.error.HTTPError as e:
+            raise CharacterizerError(f"HTTP {e.code} from {url}: {e.read()[:500]!r}") from e
+        except urllib.error.URLError as e:
+            raise CharacterizerError(f"network error to {url}: {e.reason}") from e
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError as e:
+            raise CharacterizerError(f"non-JSON response from {url}: {body[:200]!r}") from e
+
+    def _call_ollama(self, prompt: str) -> str:
+        url = f"{self.ollama_url}/api/generate"
+        payload = {
+            "model": self.model_name,
+            "prompt": prompt,
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": 0.1},
+        }
+        data = self._http_post_json(url, payload, headers={})
+        return data.get("response", "")
+
+    def _call_gemini(self, prompt: str) -> str:
+        url = (
+            "https://generativelanguage.googleapis.com/v1beta/models/"
+            f"{self.model_name}:generateContent?key={self.api_key}"
+        )
+        payload = {
+            "contents": [{"parts": [{"text": prompt}]}],
+            "generationConfig": {
+                "temperature": 0.1,
+                "responseMimeType": "application/json",
+            },
+        }
+        data = self._http_post_json(url, payload, headers={})
+        try:
+            return data["candidates"][0]["content"]["parts"][0]["text"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise CharacterizerError(f"unexpected Gemini response shape: {e}") from e
+
+    def _call_groq(self, prompt: str) -> str:
+        url = "https://api.groq.com/openai/v1/chat/completions"
+        payload = {
+            "model": self.model_name,
+            "messages": [{"role": "user", "content": prompt}],
+            "temperature": 0.1,
+            "response_format": {"type": "json_object"},
+        }
+        data = self._http_post_json(
+            url,
+            payload,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+        try:
+            return data["choices"][0]["message"]["content"]
+        except (KeyError, IndexError, TypeError) as e:
+            raise CharacterizerError(f"unexpected Groq response shape: {e}") from e
+
+    # ------------------------------------------------------------------ #
+    # response parsing + enum coercion
+    # ------------------------------------------------------------------ #
+    @staticmethod
+    def _strip_markdown(raw_text: str) -> str:
+        text = raw_text.strip()
+        # Strip leading/trailing ```json or ``` fences if present.
+        text = re.sub(r"^```(?:json)?\s*", "", text)
+        text = re.sub(r"\s*```$", "", text)
+        return text.strip()
+
+    @classmethod
+    def _parse_response(cls, raw_text: str) -> Dict[str, Any]:
+        cleaned = cls._strip_markdown(raw_text)
+        try:
+            parsed = json.loads(cleaned)
+        except json.JSONDecodeError:
+            # Fall back to the first balanced {...} block if there is any.
+            match = re.search(r"\{.*\}", cleaned, re.DOTALL)
+            if not match:
+                raise CharacterizerError("response was not parseable as JSON")
+            try:
+                parsed = json.loads(match.group(0))
+            except json.JSONDecodeError as e:
+                raise CharacterizerError(f"embedded JSON parse failed: {e}") from e
+        if not isinstance(parsed, dict):
+            raise CharacterizerError("response JSON was not an object")
+
+        # Coerce each field to its enum (with a safe fallback).
+        gate_kind = parsed.get("gate_kind")
+        bypass = parsed.get("bypass_difficulty")
+        payload = parsed.get("payload_class")
+        external_deps_raw = parsed.get("external_deps") or []
+        why_raw = parsed.get("why", "")
+
+        if not isinstance(external_deps_raw, list):
+            external_deps_raw = []
+        external_deps = [str(x) for x in external_deps_raw if isinstance(x, (str, int, float))]
+
+        return {
+            "gate_kind": gate_kind if gate_kind in GATE_KINDS else "mixed",
+            "bypass_difficulty": bypass if bypass in BYPASS_DIFFICULTIES else "unknown",
+            "payload_class": payload if payload in PAYLOAD_CLASSES else "other",
+            "external_deps": external_deps,
+            "why": str(why_raw)[:500],
+        }

--- a/Model/slicer.py
+++ b/Model/slicer.py
@@ -3,15 +3,40 @@
 Given a ``(gate_block_addr, sink_addr)`` pair from ``gate_locator``,
 this module:
 
-  1. Computes a backward slice of instructions reaching the predicate.
-  2. Lifts to angr VEX IR.
-  3. Pretty-prints to pseudo-C by shelling out to Ghidra headless
-     (``analyzeHeadless`` + a small post-script).
+  1. Computes a backward slice of basic blocks reaching the predicate
+     by BFS through the CFG (bounded by ``max_slice_hops``).
+  2. Lifts each slice block to angr VEX IR.
+  3. Resolves external-call targets in the slice into structured
+     ``ExternalCall`` records.
+  4. Optionally pretty-prints to pseudo-C by shelling out to Ghidra
+     headless (``analyzeHeadless`` + a small post-script). Requires
+     ``GHIDRA_INSTALL_DIR`` to be set; falls back to a raw VEX dump
+     when Ghidra is not available.
 
 Output is a ``GateSlice`` dataclass.
 """
+import json
+import logging
+import os
+import subprocess
+import tempfile
 from dataclasses import dataclass, field
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set
+
+log = logging.getLogger(__name__)
+
+
+GHIDRA_TIMEOUT_DEFAULT = 180
+
+
+@dataclass
+class ExternalCall:
+    """A call instruction in the slice that targets an external function."""
+
+    addr: int
+    target_name: str
+    args: List[str] = field(default_factory=list)
 
 
 @dataclass
@@ -21,13 +46,265 @@ class GateSlice:
     slice_blocks: List[int] = field(default_factory=list)
     vex_ir: str = ""
     pseudo_c: str = ""
-    external_calls: List[Dict[str, Any]] = field(default_factory=list)
+    external_calls: List[ExternalCall] = field(default_factory=list)
 
 
 class GateSlicer:
-    def __init__(self, ghidra_headless_path: str = "", project_dir: str = ""):
-        self.ghidra_headless_path = ghidra_headless_path
-        self.project_dir = project_dir
+    def __init__(
+        self,
+        ghidra_install_dir: Optional[str] = None,
+        max_slice_hops: int = 8,
+        ghidra_timeout: int = GHIDRA_TIMEOUT_DEFAULT,
+    ):
+        self.ghidra_install_dir = (
+            ghidra_install_dir
+            if ghidra_install_dir is not None
+            else os.environ.get("GHIDRA_INSTALL_DIR", "")
+        )
+        self.max_slice_hops = max(1, int(max_slice_hops))
+        self.ghidra_timeout = int(ghidra_timeout)
 
+    # ------------------------------------------------------------------ #
+    # public entry point
+    # ------------------------------------------------------------------ #
     def slice_gate(self, proj, gate_addr: int, sink_addr: int) -> GateSlice:
-        raise NotImplementedError
+        cfg = self._get_cfg(proj)
+        slice_blocks = self._walk_backward(cfg, gate_addr)
+        vex_ir = self._lift_to_vex(proj, slice_blocks)
+        external_calls = self._find_external_calls(proj, slice_blocks)
+        pseudo_c = ""
+        if self.ghidra_install_dir:
+            pseudo_c = self._try_ghidra(proj, slice_blocks)
+        if not pseudo_c:
+            pseudo_c = vex_ir  # graceful fallback
+        return GateSlice(
+            gate_addr=gate_addr,
+            sink_addr=sink_addr,
+            slice_blocks=list(slice_blocks),
+            vex_ir=vex_ir,
+            pseudo_c=pseudo_c,
+            external_calls=external_calls,
+        )
+
+    # ------------------------------------------------------------------ #
+    # backward CFG walk
+    # ------------------------------------------------------------------ #
+    def _get_cfg(self, proj):
+        try:
+            cached = proj.kb.cfgs.get_most_accurate()
+            if cached is not None:
+                return cached
+        except Exception as e:
+            log.debug(f"no cached CFG: {e}")
+        return proj.analyses.CFGFast(normalize=True)
+
+    def _walk_backward(self, cfg, gate_addr: int) -> List[int]:
+        target_node = self._find_node(cfg, gate_addr)
+        if target_node is None:
+            return [gate_addr]
+
+        visited: Set[int] = {target_node.addr}
+        order: List[int] = [target_node.addr]
+        frontier = [target_node]
+        for _ in range(self.max_slice_hops):
+            next_frontier = []
+            for node in frontier:
+                preds = self._predecessors(cfg, node)
+                for pred in preds:
+                    pred_addr = getattr(pred, "addr", None)
+                    if pred_addr is None or pred_addr in visited:
+                        continue
+                    visited.add(pred_addr)
+                    order.append(pred_addr)
+                    next_frontier.append(pred)
+            if not next_frontier:
+                break
+            frontier = next_frontier
+        return order
+
+    @staticmethod
+    def _find_node(cfg, target_addr: int):
+        try:
+            for node in cfg.graph.nodes():
+                if getattr(node, "addr", None) == target_addr:
+                    return node
+        except Exception as e:
+            log.debug(f"CFG node iteration failed: {e}")
+        return None
+
+    @staticmethod
+    def _predecessors(cfg, node) -> List[Any]:
+        try:
+            return list(cfg.graph.predecessors(node))
+        except Exception as e:
+            log.debug(f"predecessors lookup failed for {node!r}: {e}")
+            return []
+
+    # ------------------------------------------------------------------ #
+    # VEX dump
+    # ------------------------------------------------------------------ #
+    def _lift_to_vex(self, proj, block_addrs: List[int]) -> str:
+        parts: List[str] = []
+        for addr in block_addrs:
+            try:
+                block = proj.factory.block(addr)
+                parts.append(f"// ---- block at {hex(addr)} ----")
+                parts.append(str(block.vex))
+            except Exception as e:
+                log.debug(f"VEX lift failed at {hex(addr)}: {e}")
+                parts.append(f"// ---- block at {hex(addr)} (lift failed) ----")
+        return "\n".join(parts)
+
+    # ------------------------------------------------------------------ #
+    # external-call resolution
+    # ------------------------------------------------------------------ #
+    def _find_external_calls(self, proj, block_addrs: List[int]) -> List[ExternalCall]:
+        calls: List[ExternalCall] = []
+        for addr in block_addrs:
+            try:
+                block = proj.factory.block(addr)
+                for insn in block.capstone.insns:
+                    if insn.mnemonic not in ("call", "callq"):
+                        continue
+                    target_name = self._resolve_call_target(proj, insn.op_str)
+                    if target_name:
+                        calls.append(ExternalCall(addr=insn.address, target_name=target_name))
+            except Exception as e:
+                log.debug(f"external-call scan failed at {hex(addr)}: {e}")
+        return calls
+
+    @staticmethod
+    def _resolve_call_target(proj, op_str: str) -> Optional[str]:
+        try:
+            cleaned = op_str.strip()
+            if not cleaned:
+                return None
+            if not cleaned.startswith("0x"):
+                # Could be a register or a symbol literal; let kb resolve symbols.
+                try:
+                    sym = proj.loader.find_symbol(cleaned)
+                    if sym is not None:
+                        return sym.name
+                except Exception:
+                    pass
+                return None
+            target_addr = int(cleaned, 16)
+            try:
+                if target_addr in proj.kb.functions:
+                    return proj.kb.functions[target_addr].name
+            except Exception:
+                pass
+            try:
+                for plt_addr, name in proj.loader.main_object.plt.items():
+                    if plt_addr == target_addr:
+                        return name
+            except Exception:
+                pass
+        except Exception as e:
+            log.debug(f"resolve_call_target failed for {op_str!r}: {e}")
+        return None
+
+    # ------------------------------------------------------------------ #
+    # Ghidra headless integration
+    # ------------------------------------------------------------------ #
+    def _try_ghidra(self, proj, block_addrs: List[int]) -> str:
+        try:
+            binary_path = getattr(proj, "filename", None)
+            if not binary_path or not os.path.isfile(binary_path):
+                log.debug("Ghidra: no binary file path on project")
+                return ""
+            headless = self._ghidra_headless_executable()
+            if not headless or not os.path.isfile(headless):
+                log.debug(f"Ghidra: analyzeHeadless not found at {headless}")
+                return ""
+
+            with tempfile.TemporaryDirectory(prefix="logictrap_ghidra_") as tmp:
+                script_path = os.path.join(tmp, "decompile_slice.py")
+                out_path = os.path.join(tmp, "out.c")
+                project_dir = os.path.join(tmp, "ghidra_project")
+                os.makedirs(project_dir, exist_ok=True)
+
+                with open(script_path, "w", encoding="utf-8") as f:
+                    f.write(self._ghidra_postscript())
+
+                cmd = [
+                    headless,
+                    project_dir,
+                    "LogictrapDecompile",
+                    "-import", binary_path,
+                    "-postScript", script_path, out_path, json.dumps([hex(a) for a in block_addrs]),
+                    "-deleteProject",
+                    "-overwrite",
+                    "-readOnly",
+                ]
+                result = subprocess.run(
+                    cmd,
+                    capture_output=True,
+                    timeout=self.ghidra_timeout,
+                    text=True,
+                )
+                if result.returncode != 0:
+                    log.debug(f"Ghidra returned {result.returncode}: {result.stderr[:500]}")
+                    return ""
+                if not os.path.isfile(out_path):
+                    log.debug("Ghidra: output file not produced")
+                    return ""
+                with open(out_path, "r", encoding="utf-8") as f:
+                    return f.read()
+        except subprocess.TimeoutExpired:
+            log.debug("Ghidra invocation timed out")
+            return ""
+        except Exception as e:
+            log.debug(f"Ghidra invocation failed: {e}")
+            return ""
+
+    def _ghidra_headless_executable(self) -> str:
+        if not self.ghidra_install_dir:
+            return ""
+        support = Path(self.ghidra_install_dir) / "support"
+        if os.name == "nt":
+            return str(support / "analyzeHeadless.bat")
+        return str(support / "analyzeHeadless")
+
+    @staticmethod
+    def _ghidra_postscript() -> str:
+        """Ghidra post-script: decompile every function containing a slice
+        block and concatenate the C output. Runs inside Ghidra's Jython."""
+        return r"""
+# logictrap-detector slice decompilation post-script
+import json
+import sys
+
+from ghidra.app.decompiler import DecompInterface
+from ghidra.util.task import ConsoleTaskMonitor
+
+args = getScriptArgs()
+if len(args) < 2:
+    print("usage: decompile_slice.py <out_path> <addrs_json>")
+    sys.exit(1)
+out_path = args[0]
+target_addrs = [int(a, 16) for a in json.loads(args[1])]
+
+di = DecompInterface()
+di.openProgram(currentProgram)
+
+seen = set()
+out_parts = []
+addr_factory = currentProgram.getAddressFactory()
+for raw in target_addrs:
+    addr = addr_factory.getDefaultAddressSpace().getAddress(raw)
+    func = getFunctionContaining(addr)
+    if func is None:
+        continue
+    key = func.getEntryPoint().getOffset()
+    if key in seen:
+        continue
+    seen.add(key)
+    res = di.decompileFunction(func, 60, ConsoleTaskMonitor())
+    if res is not None and res.getDecompiledFunction() is not None:
+        out_parts.append("// ---- " + func.getName() + " @ " + str(func.getEntryPoint()) + " ----")
+        out_parts.append(res.getDecompiledFunction().getC())
+
+with open(out_path, "w") as f:
+    f.write("\n".join(out_parts))
+"""

--- a/tests/test_characterizer.py
+++ b/tests/test_characterizer.py
@@ -1,0 +1,330 @@
+"""Unit tests for the LLM characterizer.
+
+Avoids real network calls. Backend dispatch is exercised by
+monkeypatching ``_http_post_json`` (or the per-backend method) to
+return canned dicts.
+"""
+import pytest
+
+from characterizer import (
+    BYPASS_DIFFICULTIES,
+    Characterizer,
+    CharacterizerError,
+    DEFAULT_MODELS,
+    GATE_KINDS,
+    GateCharacterization,
+    PAYLOAD_CLASSES,
+    SUPPORTED_BACKENDS,
+)
+
+
+# --------------------------------------------------------------------- #
+# helpers
+# --------------------------------------------------------------------- #
+class _StubExternalCall:
+    def __init__(self, addr, target_name, args=None):
+        self.addr = addr
+        self.target_name = target_name
+        self.args = args or []
+
+
+class _StubGateSlice:
+    def __init__(
+        self,
+        gate_addr=0x401000,
+        sink_addr=0x402000,
+        external_calls=None,
+        pseudo_c="",
+        vex_ir="",
+    ):
+        self.gate_addr = gate_addr
+        self.sink_addr = sink_addr
+        self.external_calls = external_calls or []
+        self.pseudo_c = pseudo_c
+        self.vex_ir = vex_ir
+
+
+def _scrub_backend_env(monkeypatch):
+    for var in ("LOGICTRAP_LLM", "LOGICTRAP_MODEL", "GOOGLE_API_KEY", "GROQ_API_KEY", "OLLAMA_URL"):
+        monkeypatch.delenv(var, raising=False)
+
+
+# --------------------------------------------------------------------- #
+# constructor / configuration
+# --------------------------------------------------------------------- #
+class TestConstructor:
+    def test_defaults_to_ollama(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        ch = Characterizer()
+        assert ch.backend == "ollama"
+        assert ch.model_name == DEFAULT_MODELS["ollama"]
+        assert ch.api_key is None
+        assert ch.ollama_url == "http://localhost:11434"
+
+    def test_explicit_backend_overrides_env(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        monkeypatch.setenv("LOGICTRAP_LLM", "groq")
+        monkeypatch.setenv("GROQ_API_KEY", "env-key")
+        ch = Characterizer(backend="ollama")
+        assert ch.backend == "ollama"
+
+    def test_unknown_backend_raises(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        with pytest.raises(CharacterizerError, match="unknown backend"):
+            Characterizer(backend="not-a-thing")
+
+    def test_gemini_requires_google_api_key(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        with pytest.raises(CharacterizerError, match="GOOGLE_API_KEY"):
+            Characterizer(backend="gemini")
+
+    def test_groq_requires_groq_api_key(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        with pytest.raises(CharacterizerError, match="GROQ_API_KEY"):
+            Characterizer(backend="groq")
+
+    def test_gemini_picks_up_env_key(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "abc123")
+        ch = Characterizer(backend="gemini")
+        assert ch.api_key == "abc123"
+        assert ch.model_name == DEFAULT_MODELS["gemini"]
+
+    def test_logictrap_model_env_overrides_default(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        monkeypatch.setenv("LOGICTRAP_MODEL", "qwen2.5-coder:14b")
+        ch = Characterizer(backend="ollama")
+        assert ch.model_name == "qwen2.5-coder:14b"
+
+    def test_ollama_url_env_override(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        monkeypatch.setenv("OLLAMA_URL", "http://gpu-box:11434/")
+        ch = Characterizer(backend="ollama")
+        assert ch.ollama_url == "http://gpu-box:11434"  # trailing slash stripped
+
+
+class TestBackendCatalog:
+    def test_supported_backends_match_default_models(self):
+        assert set(SUPPORTED_BACKENDS) == set(DEFAULT_MODELS)
+
+
+# --------------------------------------------------------------------- #
+# prompt building
+# --------------------------------------------------------------------- #
+class TestBuildPrompt:
+    @pytest.fixture
+    def ch(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        return Characterizer(backend="ollama")
+
+    def test_prompt_contains_gate_and_sink_addrs(self, ch):
+        gs = _StubGateSlice(gate_addr=0x401234, sink_addr=0x402abc)
+        prompt = ch._build_prompt(gs)
+        assert "0x401234" in prompt
+        assert "0x402abc" in prompt
+
+    def test_prompt_lists_external_calls(self, ch):
+        gs = _StubGateSlice(external_calls=[
+            _StubExternalCall(0x401100, "getenv", args=['"LANG"']),
+            _StubExternalCall(0x401120, "time"),
+        ])
+        prompt = ch._build_prompt(gs)
+        assert "getenv" in prompt
+        assert '"LANG"' in prompt
+        assert "time" in prompt
+
+    def test_prompt_marks_no_external_calls(self, ch):
+        gs = _StubGateSlice(external_calls=[])
+        prompt = ch._build_prompt(gs)
+        assert "(none detected)" in prompt
+
+    def test_prompt_uses_pseudo_c_when_available(self, ch):
+        gs = _StubGateSlice(pseudo_c="if (x ^ 0x4B == 0x80) ...", vex_ir="t0 = ...")
+        prompt = ch._build_prompt(gs)
+        assert "if (x ^ 0x4B == 0x80)" in prompt
+        # vex_ir is fallback; not used here because pseudo_c is present.
+        assert "t0 = ..." not in prompt
+
+    def test_prompt_falls_back_to_vex(self, ch):
+        gs = _StubGateSlice(pseudo_c="", vex_ir="t0 = something")
+        prompt = ch._build_prompt(gs)
+        assert "t0 = something" in prompt
+
+    def test_prompt_handles_missing_decompilation(self, ch):
+        gs = _StubGateSlice(pseudo_c="", vex_ir="")
+        prompt = ch._build_prompt(gs)
+        assert "(no decompilation available)" in prompt
+
+    def test_prompt_mentions_all_enum_options(self, ch):
+        gs = _StubGateSlice()
+        prompt = ch._build_prompt(gs)
+        for kind in GATE_KINDS:
+            assert kind in prompt
+        for diff in BYPASS_DIFFICULTIES:
+            assert diff in prompt
+        for cls in PAYLOAD_CLASSES:
+            assert cls in prompt
+
+
+# --------------------------------------------------------------------- #
+# response parsing
+# --------------------------------------------------------------------- #
+VALID_RESPONSE = (
+    '{"gate_kind": "env", "external_deps": ["getenv:LANG"], '
+    '"bypass_difficulty": "env-controllable", "payload_class": "shell-exec", '
+    '"why": "Predicate compares getenv(\\"LANG\\") against null."}'
+)
+
+
+class TestParseResponse:
+    def test_parses_valid_json(self):
+        parsed = Characterizer._parse_response(VALID_RESPONSE)
+        assert parsed["gate_kind"] == "env"
+        assert parsed["external_deps"] == ["getenv:LANG"]
+        assert parsed["bypass_difficulty"] == "env-controllable"
+        assert parsed["payload_class"] == "shell-exec"
+        assert "getenv" in parsed["why"]
+
+    def test_strips_markdown_fences(self):
+        wrapped = f"```json\n{VALID_RESPONSE}\n```"
+        parsed = Characterizer._parse_response(wrapped)
+        assert parsed["gate_kind"] == "env"
+
+    def test_strips_bare_fences(self):
+        wrapped = f"```\n{VALID_RESPONSE}\n```"
+        parsed = Characterizer._parse_response(wrapped)
+        assert parsed["gate_kind"] == "env"
+
+    def test_extracts_embedded_json_when_chatter_present(self):
+        wrapped = "Here you go:\n" + VALID_RESPONSE + "\nHope that helps!"
+        parsed = Characterizer._parse_response(wrapped)
+        assert parsed["gate_kind"] == "env"
+
+    def test_unknown_gate_kind_falls_back_to_mixed(self):
+        parsed = Characterizer._parse_response(
+            '{"gate_kind": "magic", "bypass_difficulty": "trivial", "payload_class": "other"}'
+        )
+        assert parsed["gate_kind"] == "mixed"
+
+    def test_unknown_bypass_difficulty_falls_back_to_unknown(self):
+        parsed = Characterizer._parse_response(
+            '{"gate_kind": "env", "bypass_difficulty": "easy", "payload_class": "other"}'
+        )
+        assert parsed["bypass_difficulty"] == "unknown"
+
+    def test_unknown_payload_class_falls_back_to_other(self):
+        parsed = Characterizer._parse_response(
+            '{"gate_kind": "env", "bypass_difficulty": "trivial", "payload_class": "rm-rf"}'
+        )
+        assert parsed["payload_class"] == "other"
+
+    def test_external_deps_non_list_becomes_empty(self):
+        parsed = Characterizer._parse_response(
+            '{"gate_kind": "env", "external_deps": "getenv", "bypass_difficulty": "trivial", "payload_class": "other"}'
+        )
+        assert parsed["external_deps"] == []
+
+    def test_why_is_truncated(self):
+        long_why = "a" * 1000
+        parsed = Characterizer._parse_response(
+            '{"gate_kind": "env", "bypass_difficulty": "trivial", "payload_class": "other", "why": "%s"}'
+            % long_why
+        )
+        assert len(parsed["why"]) == 500
+
+    def test_garbage_response_raises(self):
+        with pytest.raises(CharacterizerError, match="not parseable as JSON"):
+            Characterizer._parse_response("totally not json")
+
+    def test_non_object_json_raises(self):
+        with pytest.raises(CharacterizerError, match="not an object"):
+            Characterizer._parse_response("[1, 2, 3]")
+
+
+# --------------------------------------------------------------------- #
+# end-to-end with mocked transport
+# --------------------------------------------------------------------- #
+class TestCharacterizeEndToEnd:
+    def test_returns_populated_characterization(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        ch = Characterizer(backend="ollama")
+
+        def fake_call(self, prompt):
+            return VALID_RESPONSE
+
+        monkeypatch.setattr(Characterizer, "_call_llm", fake_call)
+        gs = _StubGateSlice(gate_addr=0x401000)
+        out = ch.characterize(gs)
+        assert isinstance(out, GateCharacterization)
+        assert out.gate_addr == 0x401000
+        assert out.gate_kind == "env"
+        assert out.bypass_difficulty == "env-controllable"
+        assert out.payload_class == "shell-exec"
+        assert out.external_deps == ["getenv:LANG"]
+        assert out.model == DEFAULT_MODELS["ollama"]
+
+    def test_propagates_transport_errors(self, monkeypatch):
+        _scrub_backend_env(monkeypatch)
+        ch = Characterizer(backend="ollama")
+
+        def fake_call(self, prompt):
+            raise CharacterizerError("simulated network outage")
+
+        monkeypatch.setattr(Characterizer, "_call_llm", fake_call)
+        with pytest.raises(CharacterizerError, match="network outage"):
+            ch.characterize(_StubGateSlice())
+
+
+# --------------------------------------------------------------------- #
+# backend dispatch
+# --------------------------------------------------------------------- #
+class TestBackendDispatch:
+    @pytest.fixture
+    def captured(self):
+        return {}
+
+    @pytest.fixture
+    def fake_post(self, captured):
+        def _post(self, url, payload, headers):
+            captured["url"] = url
+            captured["payload"] = payload
+            captured["headers"] = headers
+            # Plausible per-backend response shapes:
+            if "api/generate" in url:  # ollama
+                return {"response": VALID_RESPONSE}
+            if "generativelanguage.googleapis.com" in url:  # gemini
+                return {"candidates": [{"content": {"parts": [{"text": VALID_RESPONSE}]}}]}
+            if "api.groq.com" in url:  # groq
+                return {"choices": [{"message": {"content": VALID_RESPONSE}}]}
+            return {}
+
+        return _post
+
+    def test_ollama_dispatch(self, monkeypatch, captured, fake_post):
+        _scrub_backend_env(monkeypatch)
+        ch = Characterizer(backend="ollama")
+        monkeypatch.setattr(Characterizer, "_http_post_json", fake_post)
+        ch.characterize(_StubGateSlice())
+        assert "api/generate" in captured["url"]
+        assert captured["payload"]["model"] == DEFAULT_MODELS["ollama"]
+        assert captured["payload"]["format"] == "json"
+
+    def test_gemini_dispatch(self, monkeypatch, captured, fake_post):
+        _scrub_backend_env(monkeypatch)
+        monkeypatch.setenv("GOOGLE_API_KEY", "test-key")
+        ch = Characterizer(backend="gemini")
+        monkeypatch.setattr(Characterizer, "_http_post_json", fake_post)
+        ch.characterize(_StubGateSlice())
+        assert "generativelanguage.googleapis.com" in captured["url"]
+        assert "key=test-key" in captured["url"]
+        assert captured["payload"]["generationConfig"]["responseMimeType"] == "application/json"
+
+    def test_groq_dispatch(self, monkeypatch, captured, fake_post):
+        _scrub_backend_env(monkeypatch)
+        monkeypatch.setenv("GROQ_API_KEY", "test-key")
+        ch = Characterizer(backend="groq")
+        monkeypatch.setattr(Characterizer, "_http_post_json", fake_post)
+        ch.characterize(_StubGateSlice())
+        assert "api.groq.com" in captured["url"]
+        assert captured["headers"]["Authorization"] == "Bearer test-key"
+        assert captured["payload"]["response_format"]["type"] == "json_object"

--- a/tests/test_slicer.py
+++ b/tests/test_slicer.py
@@ -1,0 +1,272 @@
+"""Unit tests for the gate slicer.
+
+We avoid spinning up real angr Projects (heavy, slow, depend on
+binaries). Instead, lightweight stub classes mimic only the surface
+the slicer touches: ``cfg.graph.nodes()``, ``cfg.graph.predecessors``,
+``proj.factory.block``, ``proj.kb.functions``, ``proj.loader``.
+"""
+import pytest
+
+from slicer import (
+    ExternalCall,
+    GateSlice,
+    GateSlicer,
+)
+
+
+# --------------------------------------------------------------------- #
+# stub helpers
+# --------------------------------------------------------------------- #
+class _Node:
+    def __init__(self, addr: int):
+        self.addr = addr
+
+    def __repr__(self):
+        return f"<Node {hex(self.addr)}>"
+
+
+class _Graph:
+    def __init__(self, edges):
+        # edges: list of (src_addr, dst_addr); each addr becomes a Node.
+        addrs = set()
+        for src, dst in edges:
+            addrs.update((src, dst))
+        self._nodes = {a: _Node(a) for a in addrs}
+        self._preds: dict = {a: set() for a in addrs}
+        for src, dst in edges:
+            self._preds[dst].add(src)
+
+    def add_isolated(self, addr: int):
+        if addr not in self._nodes:
+            self._nodes[addr] = _Node(addr)
+            self._preds[addr] = set()
+
+    def nodes(self):
+        return list(self._nodes.values())
+
+    def predecessors(self, node):
+        addrs = self._preds.get(node.addr, set())
+        return [self._nodes[a] for a in addrs]
+
+
+class _CFG:
+    def __init__(self, graph):
+        self.graph = graph
+
+
+# --------------------------------------------------------------------- #
+# constructor defaults
+# --------------------------------------------------------------------- #
+class TestSlicerDefaults:
+    def test_uses_env_var_for_ghidra(self, monkeypatch):
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", "/opt/ghidra")
+        slicer = GateSlicer()
+        assert slicer.ghidra_install_dir == "/opt/ghidra"
+
+    def test_explicit_arg_overrides_env(self, monkeypatch):
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", "/opt/ghidra")
+        slicer = GateSlicer(ghidra_install_dir="/usr/local/ghidra")
+        assert slicer.ghidra_install_dir == "/usr/local/ghidra"
+
+    def test_empty_string_disables_ghidra(self, monkeypatch):
+        monkeypatch.delenv("GHIDRA_INSTALL_DIR", raising=False)
+        slicer = GateSlicer()
+        assert slicer.ghidra_install_dir == ""
+
+    def test_max_hops_floors_at_one(self):
+        slicer = GateSlicer(max_slice_hops=0)
+        assert slicer.max_slice_hops == 1
+
+    def test_negative_hops_floors_at_one(self):
+        slicer = GateSlicer(max_slice_hops=-3)
+        assert slicer.max_slice_hops == 1
+
+
+# --------------------------------------------------------------------- #
+# backward walk
+# --------------------------------------------------------------------- #
+class TestWalkBackward:
+    def test_target_only_when_no_predecessors(self):
+        cfg = _CFG(_Graph([]))
+        cfg.graph.add_isolated(0x1000)
+        slicer = GateSlicer(max_slice_hops=5)
+        order = slicer._walk_backward(cfg, 0x1000)
+        assert order == [0x1000]
+
+    def test_missing_target_falls_back_to_address_only(self):
+        cfg = _CFG(_Graph([(0x1000, 0x2000)]))
+        slicer = GateSlicer(max_slice_hops=5)
+        order = slicer._walk_backward(cfg, 0xDEADBEEF)
+        assert order == [0xDEADBEEF]
+
+    def test_collects_chain(self):
+        # 0x1000 -> 0x2000 -> 0x3000 (gate)
+        cfg = _CFG(_Graph([(0x1000, 0x2000), (0x2000, 0x3000)]))
+        slicer = GateSlicer(max_slice_hops=5)
+        order = slicer._walk_backward(cfg, 0x3000)
+        assert order[0] == 0x3000
+        assert set(order) == {0x1000, 0x2000, 0x3000}
+
+    def test_respects_max_hops(self):
+        # 0x1000 -> 0x2000 -> 0x3000 -> 0x4000 (gate). With max_slice_hops=1
+        # we should only collect the direct predecessor.
+        cfg = _CFG(_Graph([(0x1000, 0x2000), (0x2000, 0x3000), (0x3000, 0x4000)]))
+        slicer = GateSlicer(max_slice_hops=1)
+        order = slicer._walk_backward(cfg, 0x4000)
+        assert set(order) == {0x4000, 0x3000}
+        assert 0x2000 not in order
+        assert 0x1000 not in order
+
+    def test_handles_diamond(self):
+        # 0x1000 -> 0x2000
+        # 0x1000 -> 0x3000
+        # 0x2000 -> 0x4000 (gate)
+        # 0x3000 -> 0x4000 (gate)
+        cfg = _CFG(_Graph([
+            (0x1000, 0x2000),
+            (0x1000, 0x3000),
+            (0x2000, 0x4000),
+            (0x3000, 0x4000),
+        ]))
+        slicer = GateSlicer(max_slice_hops=5)
+        order = slicer._walk_backward(cfg, 0x4000)
+        assert set(order) == {0x1000, 0x2000, 0x3000, 0x4000}
+
+    def test_cycle_does_not_loop_forever(self):
+        # 0x1000 -> 0x2000 -> 0x1000 cycle, plus 0x2000 -> 0x3000 gate.
+        cfg = _CFG(_Graph([
+            (0x1000, 0x2000),
+            (0x2000, 0x1000),
+            (0x2000, 0x3000),
+        ]))
+        slicer = GateSlicer(max_slice_hops=10)
+        order = slicer._walk_backward(cfg, 0x3000)
+        # Each node visited at most once.
+        assert len(order) == len(set(order))
+        assert set(order) == {0x1000, 0x2000, 0x3000}
+
+
+# --------------------------------------------------------------------- #
+# external call resolution
+# --------------------------------------------------------------------- #
+class _StubFunc:
+    def __init__(self, name):
+        self.name = name
+
+
+class _StubFunctions:
+    def __init__(self, mapping):
+        self._mapping = mapping  # {addr: name}
+
+    def __contains__(self, addr):
+        return addr in self._mapping
+
+    def __getitem__(self, addr):
+        return _StubFunc(self._mapping[addr])
+
+
+class _StubKB:
+    def __init__(self, functions=None):
+        self.functions = _StubFunctions(functions or {})
+
+
+class _StubPLT:
+    def __init__(self, mapping):
+        self._mapping = mapping  # {addr: name}
+
+    def items(self):
+        return list(self._mapping.items())
+
+
+class _StubMainObject:
+    def __init__(self, plt=None):
+        self.plt = _StubPLT(plt or {})
+
+
+class _StubLoader:
+    def __init__(self, plt=None, symbols=None):
+        self.main_object = _StubMainObject(plt=plt or {})
+        self._symbols = symbols or {}
+
+    def find_symbol(self, name):
+        s = self._symbols.get(name)
+        return s
+
+
+class _Symbol:
+    def __init__(self, name):
+        self.name = name
+
+
+class _StubProj:
+    def __init__(self, functions=None, plt=None, symbols=None):
+        self.kb = _StubKB(functions=functions)
+        self.loader = _StubLoader(plt=plt, symbols=symbols)
+
+
+class TestResolveCallTarget:
+    def test_hex_addr_resolves_via_kb_functions(self):
+        proj = _StubProj(functions={0x401234: "system"})
+        assert GateSlicer._resolve_call_target(proj, "0x401234") == "system"
+
+    def test_hex_addr_resolves_via_plt(self):
+        proj = _StubProj(plt={0x402000: "getenv"})
+        assert GateSlicer._resolve_call_target(proj, "0x402000") == "getenv"
+
+    def test_unknown_hex_addr_returns_none(self):
+        proj = _StubProj()
+        assert GateSlicer._resolve_call_target(proj, "0x99999") is None
+
+    def test_symbol_name_resolved_via_loader(self):
+        proj = _StubProj(symbols={"execve": _Symbol("execve")})
+        assert GateSlicer._resolve_call_target(proj, "execve") == "execve"
+
+    def test_register_or_unknown_string_returns_none(self):
+        proj = _StubProj()
+        assert GateSlicer._resolve_call_target(proj, "rax") is None
+        assert GateSlicer._resolve_call_target(proj, "") is None
+
+
+# --------------------------------------------------------------------- #
+# Ghidra fallback
+# --------------------------------------------------------------------- #
+class TestGhidraFallback:
+    def test_no_install_dir_returns_empty(self, monkeypatch):
+        monkeypatch.delenv("GHIDRA_INSTALL_DIR", raising=False)
+        slicer = GateSlicer()
+        assert slicer._try_ghidra(proj=object(), block_addrs=[0x1000]) == ""
+
+    def test_missing_executable_returns_empty(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("GHIDRA_INSTALL_DIR", str(tmp_path))
+        slicer = GateSlicer()
+        # support/analyzeHeadless does not exist in tmp_path -> graceful empty.
+        assert slicer._try_ghidra(proj=object(), block_addrs=[0x1000]) == ""
+
+    def test_executable_path_uses_bat_on_windows(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("os.name", "nt")
+        slicer = GateSlicer(ghidra_install_dir=str(tmp_path))
+        path = slicer._ghidra_headless_executable()
+        assert path.endswith("analyzeHeadless.bat")
+
+    def test_executable_path_no_bat_on_posix(self, monkeypatch, tmp_path):
+        monkeypatch.setattr("os.name", "posix")
+        slicer = GateSlicer(ghidra_install_dir=str(tmp_path))
+        path = slicer._ghidra_headless_executable()
+        assert path.endswith("analyzeHeadless")
+        assert not path.endswith(".bat")
+
+
+# --------------------------------------------------------------------- #
+# dataclass smoke
+# --------------------------------------------------------------------- #
+class TestDataclassDefaults:
+    def test_external_call_minimal_construction(self):
+        c = ExternalCall(addr=0x401000, target_name="getenv")
+        assert c.args == []
+
+    def test_gate_slice_minimal_construction(self):
+        s = GateSlice(gate_addr=0x401000, sink_addr=0x402000)
+        assert s.slice_blocks == []
+        assert s.vex_ir == ""
+        assert s.pseudo_c == ""
+        assert s.external_calls == []


### PR DESCRIPTION
GateSlicer.slice_gate now runs the full pipeline: a bounded backward BFS through the CFG (default 8 hops), a VEX dump of each block in the slice, external-call resolution via kb.functions / PLT entries / symbol lookups, and an optional Ghidra headless pass that decompiles every function containing a slice block, falling back gracefully to the VEX dump when GHIDRA_INSTALL_DIR is unset or the Ghidra invocation fails. Characterizer.characterize emits a structured GateCharacterization via one of three LLM backends (Ollama, Gemini, Groq) over stdlib urllib, so no new runtime dependency is added; each backend requests strict JSON output, and the parser strips markdown fences, extracts embedded JSON when the model adds chatter, and coerces invalid enum values to safe defaults (gate_kind to mixed, bypass_difficulty to unknown, payload_class to other). The backend, model, API keys, and Ollama URL are all configured via environment variables: LOGICTRAP_LLM, LOGICTRAP_MODEL, GOOGLE_API_KEY, GROQ_API_KEY, OLLAMA_URL. test_slicer.py adds 22 tests covering the backward walk (chain, diamond, cycle, missing target, hop limit), call-target resolution against stub projects, and the Ghidra fallback paths; test_characterizer.py adds 35 tests covering constructor configuration, prompt building, response-parsing edge cases, and per-backend dispatch with monkeypatched HTTP. Minor fix included: GateCharacterization.gate_kind now defaults to "mixed" rather than "unknown", which was not a member of GATE_KINDS.