### PR TITLE
Add characterization pipeline, bench reporter, and corpus manifests

### DIFF
--- a/Model/logictrapdetector.py
+++ b/Model/logictrapdetector.py
@@ -10,8 +10,12 @@ from typing import List, Tuple, Optional, Set, Dict, Any
 from collections import defaultdict
 import networkx as nx
 
+from characterizer import Characterizer, CharacterizerError
 from external_gates import ExternalGateCatalog
 from gate_locator import LogicTrapAnalyzer, SinkFinder
+from pipeline import characterize_gates
+from scorer import SinkDistanceScorer
+from slicer import GateSlicer
 
 logging.getLogger('angr').setLevel(logging.CRITICAL)
 logging.getLogger('claripy').setLevel(logging.CRITICAL)
@@ -48,6 +52,23 @@ class EnhancedShellPayloadAnalyzer:  # Orchestrates payload discovery via symbol
         self.logic_analyzer = LogicTrapAnalyzer()  # logic trap detection helper
         self.symbolic_constraints = []  # list of applied input constraints
         self.gate_solutions = {}  # concrete values for gates per state
+        self.gate_slicer = GateSlicer()  # backward slicer used by the pipeline
+        self.gate_scorer = SinkDistanceScorer()  # sink-distance scorer
+        self.gate_characterizer = self._build_characterizer()  # may be None if no LLM is configured
+        self.gates = []  # gate-centric records emitted by characterize_gates
+
+    @staticmethod
+    def _build_characterizer():
+        """Try to construct a Characterizer; return None if no backend is reachable.
+
+        Letting the characterizer be None is the supported "I don't have an
+        LLM set up" path — the rest of the pipeline still runs and produces
+        slice/score output for each gate."""
+        try:
+            return Characterizer()
+        except CharacterizerError as e:
+            log.info(f"characterizer disabled: {e}")
+            return None
 
     def load_binary(self) -> bool:
         try:
@@ -544,12 +565,24 @@ class EnhancedShellPayloadAnalyzer:  # Orchestrates payload discovery via symbol
                 except Exception as e:
                     log.debug(f"guided_symbolic_execution failed at input_size={size}: {e}")
                     continue
+        # New gate-centric pipeline: slice + score + (optional) characterize
+        # each trap. Behaviour-additive — the legacy fields above keep working.
+        self.gates = characterize_gates(
+            proj=self.proj,
+            cfg=self.cfg,
+            logic_traps=self.logic_traps,
+            sink_addrs=self.system_addrs,
+            slicer=self.gate_slicer,
+            scorer=self.gate_scorer,
+            characterizer=self.gate_characterizer,
+        )
         results = {
             'binary_path': self.binary_path,
             'discovered_gates': dict(self.gate_catalog.discovered_gates),
             'shell_strings': shell_strings,
             'system_calls': system_calls,
             'logic_traps': [(hex(addr), info) for addr, info in self.logic_traps],
+            'gates': self.gates,
             'solutions': self.found_solutions,
             'gate_solutions': self.gate_solutions,
             'analysis_success': found_any,

--- a/Model/pipeline.py
+++ b/Model/pipeline.py
@@ -1,0 +1,134 @@
+"""End-to-end gate characterization pipeline.
+
+Stitches together the four detector components into the canonical
+JSON-shaped output documented in the project README:
+
+    locate (gate_locator) ->
+        slice (slicer) ->
+            characterize (characterizer, optional) ->
+                score (scorer)
+
+Pulled out of the orchestrator so tests can exercise the loop with
+plain stubs instead of spinning up a real angr ``Project``.
+"""
+import logging
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+
+def _nearest_sink(scorer, cfg, gate_addr: int, sink_addrs: Iterable[int]) -> Optional[int]:
+    """Return the sink address with the smallest basic-block distance,
+    or None if no sinks are provided."""
+    best: Optional[int] = None
+    best_dist = float("inf")
+    for sink in sink_addrs:
+        try:
+            d = scorer.basic_blocks_between(cfg, gate_addr, sink)
+        except Exception as e:
+            log.debug(f"distance lookup failed for {hex(gate_addr)} -> {hex(sink)}: {e}")
+            continue
+        if d < best_dist:
+            best = sink
+            best_dist = d
+    return best
+
+
+def characterize_gates(
+    proj,
+    cfg,
+    logic_traps: List[Tuple[int, Dict[str, Any]]],
+    sink_addrs: Iterable[int],
+    slicer,
+    scorer,
+    characterizer=None,
+    on_error: Optional[Callable[[int, str], None]] = None,
+) -> List[Dict[str, Any]]:
+    """Run the slice -> score -> characterize loop for every trap.
+
+    ``logic_traps``: ``[(gate_addr, info_dict), ...]`` from
+    ``LogicTrapAnalyzer.find_logic_traps``. ``info_dict`` is expected to
+    have at minimum a ``score`` integer (the gate's instruction-density
+    score from the locator).
+
+    ``sink_addrs``: an iterable of dangerous-function addresses from
+    ``SinkFinder``. For each trap, the nearest sink in basic blocks is
+    paired with it.
+
+    ``characterizer`` is optional. If ``None`` or it raises during
+    ``characterize``, the gate entry is emitted without a
+    ``characterization`` field. ``on_error`` (optional) is invoked with
+    ``(gate_addr, message)`` whenever any pipeline stage fails for a
+    given gate so the caller can log it.
+    """
+    sink_addrs = list(sink_addrs)
+    if not logic_traps or not sink_addrs:
+        return []
+
+    out: List[Dict[str, Any]] = []
+    for trap_addr, trap_info in logic_traps:
+        sink_addr = _nearest_sink(scorer, cfg, trap_addr, sink_addrs)
+        if sink_addr is None:
+            continue
+
+        # --- slice ----------------------------------------------------
+        try:
+            gate_slice = slicer.slice_gate(proj, trap_addr, sink_addr)
+        except Exception as e:
+            log.debug(f"slice failed at {hex(trap_addr)}: {e}")
+            if on_error:
+                on_error(trap_addr, f"slice: {e}")
+            continue
+
+        external_deps = [
+            getattr(ec, "target_name", "?")
+            for ec in (gate_slice.external_calls or [])
+        ]
+
+        # --- score ----------------------------------------------------
+        try:
+            bb_dist = scorer.basic_blocks_between(cfg, trap_addr, sink_addr)
+        except Exception as e:
+            log.debug(f"distance lookup failed at {hex(trap_addr)}: {e}")
+            bb_dist = 999
+        gate_score = scorer.score(
+            gate_addr=trap_addr,
+            sink_addr=sink_addr,
+            gate_complexity=int(trap_info.get("score", 0)),
+            external_dep_count=len(external_deps),
+            basic_blocks_to_sink=bb_dist,
+        )
+
+        entry: Dict[str, Any] = {
+            "gate_addr": hex(trap_addr),
+            "sink_addr": hex(sink_addr),
+            "complexity": int(trap_info.get("score", 0)),
+            "external_deps": external_deps,
+            "distance_to_sink": gate_score.basic_blocks_to_sink,
+            "score": gate_score.score,
+        }
+
+        # --- characterize (optional) ----------------------------------
+        if characterizer is not None:
+            try:
+                char = characterizer.characterize(gate_slice)
+                entry["characterization"] = {
+                    "gate_kind": char.gate_kind,
+                    "bypass_difficulty": char.bypass_difficulty,
+                    "payload_class": char.payload_class,
+                    "external_deps": char.external_deps,
+                    "why": char.why,
+                    "model": char.model,
+                }
+            except Exception as e:
+                log.debug(f"characterize failed at {hex(trap_addr)}: {e}")
+                if on_error:
+                    on_error(trap_addr, f"characterize: {e}")
+                entry["characterization"] = {"error": str(e)}
+
+        out.append(entry)
+
+    # Highest-score gate first — handy for both human review and any
+    # caller that just wants the top-N.
+    out.sort(key=lambda g: g.get("score", 0.0), reverse=True)
+    return out

--- a/bench/report.py
+++ b/bench/report.py
@@ -1,0 +1,231 @@
+"""Aggregate reporter for ``bench/run.py`` output.
+
+Reads ``output/bench_results.json`` and prints per-category and overall
+metrics:
+
+  - number of samples processed, skipped, errored
+  - total gates flagged
+  - **recall** on payload-bearing samples (did at least one gate get
+    flagged for each labelled sample?)
+  - **false-positive rate** on ``has_payload: false`` samples
+    (gates flagged above the per-sample expected upper bound)
+  - **characterization match** counts where a sample's ground truth
+    sets ``gate_kinds`` / ``bypass_difficulty`` / ``sink_class`` and
+    the characterizer produced a matching value
+
+Usage::
+
+    python bench/report.py
+    python bench/report.py --results output/bench_results.json
+    python bench/report.py --json output/bench_summary.json
+"""
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DEFAULT_RESULTS = REPO_ROOT / "output" / "bench_results.json"
+
+
+def _result_gates(run: Dict[str, Any]) -> List[Dict[str, Any]]:
+    return run.get("result", {}).get("gates", []) or []
+
+
+def _ground_truth(run: Dict[str, Any]) -> Dict[str, Any]:
+    return run.get("ground_truth") or {}
+
+
+def _sample_errored(run: Dict[str, Any]) -> bool:
+    err = run.get("result", {}).get("error")
+    return bool(err)
+
+
+def summarize(runs: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Compute the aggregate metrics dictionary."""
+    by_cat: Dict[str, Dict[str, Any]] = defaultdict(lambda: {
+        "samples_total": 0,
+        "samples_errored": 0,
+        "gates_flagged": 0,
+        "positive_samples": 0,
+        "positive_samples_recalled": 0,
+        "negative_samples": 0,
+        "false_positive_samples": 0,
+        "false_positives": 0,
+        "characterization_matches": {
+            "gate_kind": 0,
+            "bypass_difficulty": 0,
+            "sink_class": 0,
+        },
+        "characterization_attempts": {
+            "gate_kind": 0,
+            "bypass_difficulty": 0,
+            "sink_class": 0,
+        },
+    })
+
+    for run in runs:
+        category = run.get("category", "uncategorized")
+        bucket = by_cat[category]
+        bucket["samples_total"] += 1
+
+        if _sample_errored(run):
+            bucket["samples_errored"] += 1
+            continue
+
+        gates = _result_gates(run)
+        bucket["gates_flagged"] += len(gates)
+        gt = _ground_truth(run)
+        has_payload = gt.get("has_payload")
+
+        if has_payload is True:
+            bucket["positive_samples"] += 1
+            if len(gates) > 0:
+                bucket["positive_samples_recalled"] += 1
+            _tally_characterization(bucket, gates, gt)
+        elif has_payload is False:
+            bucket["negative_samples"] += 1
+            upper = int(gt.get("expected_gates_flagged_upper_bound", 0))
+            extra = max(0, len(gates) - upper)
+            if extra > 0:
+                bucket["false_positive_samples"] += 1
+                bucket["false_positives"] += extra
+
+    overall = _aggregate_overall(by_cat)
+    return {
+        "by_category": dict(by_cat),
+        "overall": overall,
+    }
+
+
+def _tally_characterization(
+    bucket: Dict[str, Any],
+    gates: List[Dict[str, Any]],
+    gt: Dict[str, Any],
+) -> None:
+    if not gates:
+        return
+    # We compare against the *top-ranked* gate (highest score). The
+    # pipeline already sorts gates descending by score before returning.
+    top = gates[0]
+    char = top.get("characterization") or {}
+    if not isinstance(char, dict):
+        return
+
+    if "gate_kinds" in gt and isinstance(gt["gate_kinds"], list):
+        bucket["characterization_attempts"]["gate_kind"] += 1
+        if char.get("gate_kind") in gt["gate_kinds"]:
+            bucket["characterization_matches"]["gate_kind"] += 1
+
+    if "bypass_difficulty" in gt:
+        bucket["characterization_attempts"]["bypass_difficulty"] += 1
+        if char.get("bypass_difficulty") == gt["bypass_difficulty"]:
+            bucket["characterization_matches"]["bypass_difficulty"] += 1
+
+    if "sink_class" in gt:
+        bucket["characterization_attempts"]["sink_class"] += 1
+        if char.get("payload_class") == gt["sink_class"]:
+            bucket["characterization_matches"]["sink_class"] += 1
+
+
+def _aggregate_overall(by_cat: Dict[str, Dict[str, Any]]) -> Dict[str, Any]:
+    total = {
+        "samples_total": 0,
+        "samples_errored": 0,
+        "gates_flagged": 0,
+        "positive_samples": 0,
+        "positive_samples_recalled": 0,
+        "negative_samples": 0,
+        "false_positive_samples": 0,
+        "false_positives": 0,
+        "characterization_matches": {"gate_kind": 0, "bypass_difficulty": 0, "sink_class": 0},
+        "characterization_attempts": {"gate_kind": 0, "bypass_difficulty": 0, "sink_class": 0},
+    }
+    for cat in by_cat.values():
+        for key in ("samples_total", "samples_errored", "gates_flagged",
+                    "positive_samples", "positive_samples_recalled",
+                    "negative_samples", "false_positive_samples", "false_positives"):
+            total[key] += cat[key]
+        for field in ("gate_kind", "bypass_difficulty", "sink_class"):
+            total["characterization_matches"][field] += cat["characterization_matches"][field]
+            total["characterization_attempts"][field] += cat["characterization_attempts"][field]
+    return total
+
+
+def _pct(num: int, denom: int) -> str:
+    if denom == 0:
+        return "n/a"
+    return f"{(num / denom) * 100:.1f}%"
+
+
+def render_text(summary: Dict[str, Any]) -> str:
+    lines = []
+    lines.append("=" * 60)
+    lines.append("logictrap-detector benchmark summary")
+    lines.append("=" * 60)
+    for category, c in sorted(summary["by_category"].items()):
+        lines.append("")
+        lines.append(f"[{category}]")
+        lines.append(f"  samples processed:  {c['samples_total']} ({c['samples_errored']} errored)")
+        lines.append(f"  gates flagged:      {c['gates_flagged']}")
+        if c["positive_samples"]:
+            recall = _pct(c["positive_samples_recalled"], c["positive_samples"])
+            lines.append(f"  recall (payload):   {recall}  "
+                         f"({c['positive_samples_recalled']}/{c['positive_samples']})")
+        if c["negative_samples"]:
+            fp_rate = _pct(c["false_positive_samples"], c["negative_samples"])
+            lines.append(f"  FP rate (clean):    {fp_rate}  "
+                         f"({c['false_positive_samples']}/{c['negative_samples']} samples, "
+                         f"{c['false_positives']} excess flags)")
+        if any(c["characterization_attempts"].values()):
+            lines.append("  characterization match:")
+            for field in ("gate_kind", "bypass_difficulty", "sink_class"):
+                attempts = c["characterization_attempts"][field]
+                matches = c["characterization_matches"][field]
+                if attempts:
+                    lines.append(f"    {field:18s} {_pct(matches, attempts)}  ({matches}/{attempts})")
+
+    o = summary["overall"]
+    lines.append("")
+    lines.append("[overall]")
+    lines.append(f"  samples processed:  {o['samples_total']} ({o['samples_errored']} errored)")
+    lines.append(f"  gates flagged:      {o['gates_flagged']}")
+    if o["positive_samples"]:
+        lines.append(f"  recall (payload):   {_pct(o['positive_samples_recalled'], o['positive_samples'])}")
+    if o["negative_samples"]:
+        lines.append(f"  FP rate (clean):    {_pct(o['false_positive_samples'], o['negative_samples'])}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarize a bench/run.py results JSON.")
+    parser.add_argument("--results", default=str(DEFAULT_RESULTS),
+                        help="Path to bench_results.json.")
+    parser.add_argument("--json", default=None,
+                        help="Optional path to also write a JSON summary.")
+    args = parser.parse_args(argv)
+
+    results_path = Path(args.results)
+    if not results_path.exists():
+        print(f"results file not found: {results_path}", file=sys.stderr)
+        return 1
+    with open(results_path, encoding="utf-8") as f:
+        data = json.load(f)
+    runs = data.get("runs", [])
+    summary = summarize(runs)
+
+    print(render_text(summary))
+
+    if args.json:
+        out_path = Path(args.json)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2)
+        print(f"\n[+] wrote JSON summary to {out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/corpus/gadget-chains/manifest.json
+++ b/corpus/gadget-chains/manifest.json
@@ -1,5 +1,42 @@
 {
   "category": "gadget-chains",
-  "description": "Dormant Java deserialization gadget chains. Add per-chain subdirectories per the README.",
-  "samples": []
+  "description": "Dormant Java deserialization gadget chains. Each sample is a JAR (or pair of JARs) whose deserialization path leads to remote code execution under a minor, stealthy modification. Populate per the README before running the harness.",
+  "samples": [
+    {
+      "id": "chain-01-commons-collections",
+      "path": "corpus/gadget-chains/chain-01-commons-collections/modified.jar",
+      "source": "corpus/gadget-chains/chain-01-commons-collections/original.jar",
+      "ground_truth": {
+        "has_payload": true,
+        "sink_class": "deserialize",
+        "gate_kinds": ["mixed"],
+        "bypass_difficulty": "trivial",
+        "trigger_note": "Transformer chain reachable through a single readObject; activates without environmental checks."
+      }
+    },
+    {
+      "id": "chain-02-spring-aop",
+      "path": "corpus/gadget-chains/chain-02-spring-aop/modified.jar",
+      "source": "corpus/gadget-chains/chain-02-spring-aop/original.jar",
+      "ground_truth": {
+        "has_payload": true,
+        "sink_class": "deserialize",
+        "gate_kinds": ["mixed"],
+        "bypass_difficulty": "trivial",
+        "trigger_note": "AOP advice invocation reaches Runtime.exec via reflective dispatch."
+      }
+    },
+    {
+      "id": "chain-03-jython-runtime",
+      "path": "corpus/gadget-chains/chain-03-jython-runtime/modified.jar",
+      "source": "corpus/gadget-chains/chain-03-jython-runtime/original.jar",
+      "ground_truth": {
+        "has_payload": true,
+        "sink_class": "deserialize",
+        "gate_kinds": ["mixed"],
+        "bypass_difficulty": "trivial",
+        "trigger_note": "Embedded Jython script runs at deserialization time and reaches a JIT writable function pointer."
+      }
+    }
+  ]
 }

--- a/corpus/negatives/manifest.json
+++ b/corpus/negatives/manifest.json
@@ -1,5 +1,96 @@
 {
   "category": "negatives",
-  "description": "Clean binaries used to measure false-positive rate. Populate per the README.",
-  "samples": []
+  "description": "Clean utility binaries used to measure false-positive rate of the gate locator and characterizer. Paths point at standard Linux system installs; samples whose path does not resolve on the runner are skipped by bench/run.py and do not count as failures.",
+  "samples": [
+    {
+      "id": "neg-coreutils-ls",
+      "path": "/usr/bin/ls",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 0,
+        "note": "Heavy on locale and dirent checks; should not be flagged as crypto/process trigger."
+      }
+    },
+    {
+      "id": "neg-coreutils-cat",
+      "path": "/usr/bin/cat",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 0,
+        "note": "Small, mostly read/write loops with no environment gating."
+      }
+    },
+    {
+      "id": "neg-coreutils-grep",
+      "path": "/usr/bin/grep",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 1,
+        "note": "Locale-aware regex engine; one or two complexity-heavy blocks are not a true positive."
+      }
+    },
+    {
+      "id": "neg-coreutils-find",
+      "path": "/usr/bin/find",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 1,
+        "note": "Filter predicates can look like gates; argv parsing is benign."
+      }
+    },
+    {
+      "id": "neg-coreutils-cp",
+      "path": "/usr/bin/cp",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 0,
+        "note": "Mode/owner copy logic; no payload."
+      }
+    },
+    {
+      "id": "neg-coreutils-mv",
+      "path": "/usr/bin/mv",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 0,
+        "note": "Rename + fallback copy; no payload."
+      }
+    },
+    {
+      "id": "neg-bash",
+      "path": "/bin/bash",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 3,
+        "note": "Bash legitimately calls system primitives in many places; a few flagged gates are expected."
+      }
+    },
+    {
+      "id": "neg-git",
+      "path": "/usr/bin/git",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 2,
+        "note": "GIT_* env vars and config-file reads create env-shaped predicates."
+      }
+    },
+    {
+      "id": "neg-ssh",
+      "path": "/usr/bin/ssh",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 2,
+        "note": "Process-checking and env-dependent behavior; should NOT flag a crypto-gated shell-exec."
+      }
+    },
+    {
+      "id": "neg-curl",
+      "path": "/usr/bin/curl",
+      "ground_truth": {
+        "has_payload": false,
+        "expected_gates_flagged_upper_bound": 2,
+        "note": "Network-heavy: many env vars + URL parsing; expected to look gate-like but benign."
+      }
+    }
+  ]
 }

--- a/corpus/xz/manifest.json
+++ b/corpus/xz/manifest.json
@@ -1,5 +1,27 @@
 {
   "category": "xz",
-  "description": "XZ Utils backdoor artifacts (CVE-2024-3094). Populate per the README before running the harness.",
-  "samples": []
+  "description": "XZ Utils backdoor artifacts (CVE-2024-3094). The Ed448 signature gate is information-theoretically uncrackable; the analyzer should report bypass_difficulty: crypto-hard rather than attempt symbolic solving. Populate the binary file per the README before running the harness.",
+  "samples": [
+    {
+      "id": "xz-liblzma-5.6.1",
+      "path": "corpus/xz/liblzma.so.5.6.1",
+      "source": null,
+      "ground_truth": {
+        "has_payload": true,
+        "sink_class": "shell-exec",
+        "gate_kinds": ["crypto", "process", "env"],
+        "bypass_difficulty": "crypto-hard",
+        "expected_predicates": [
+          {"name": "ed448_signature_verify", "kind": "crypto"},
+          {"name": "argv0_endswith_/sshd",   "kind": "process"},
+          {"name": "TERM_unset",              "kind": "env"},
+          {"name": "LD_DEBUG_unset",          "kind": "env"},
+          {"name": "LD_PROFILE_unset",        "kind": "env"},
+          {"name": "LANG_set",                "kind": "env"},
+          {"name": "no_debugger_attached",    "kind": "process"}
+        ],
+        "trigger_note": "Activation requires both a valid Ed448 signature and the environment to match an SSHd startup; symex and fuzzing cannot satisfy the crypto check."
+      }
+    }
+  ]
 }

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,265 @@
+"""Unit tests for the gate-characterization pipeline.
+
+The pipeline glues four collaborators (slicer, scorer, characterizer,
+plus an angr CFG). We supply small stand-ins for each so the loop's
+control flow can be exercised in isolation.
+"""
+import pytest
+
+from pipeline import characterize_gates
+from scorer import GateScore
+
+
+# --------------------------------------------------------------------- #
+# stubs
+# --------------------------------------------------------------------- #
+class _StubExternalCall:
+    def __init__(self, target_name):
+        self.target_name = target_name
+
+
+class _StubGateSlice:
+    def __init__(self, gate_addr=0x401000, external_calls=None):
+        self.gate_addr = gate_addr
+        self.external_calls = external_calls or []
+
+
+class _StubSlicer:
+    """Records every slice request and returns a configurable slice."""
+
+    def __init__(self, external_calls=None, raise_on_addrs=None):
+        self.external_calls = external_calls or []
+        self.raise_on_addrs = set(raise_on_addrs or [])
+        self.calls = []
+
+    def slice_gate(self, proj, gate_addr, sink_addr):
+        self.calls.append((gate_addr, sink_addr))
+        if gate_addr in self.raise_on_addrs:
+            raise RuntimeError(f"simulated slice failure at {hex(gate_addr)}")
+        return _StubGateSlice(gate_addr=gate_addr, external_calls=self.external_calls)
+
+
+class _StubScorer:
+    """Distance is dictated by a lookup table. Score is the
+    SinkDistanceScorer formula so tests verify behavior end-to-end."""
+
+    def __init__(self, distances):
+        # distances: {(gate_addr, sink_addr): int}
+        self.distances = distances
+
+    def basic_blocks_between(self, cfg, src, dst):
+        return self.distances.get((src, dst), 10)
+
+    def score(self, gate_addr, sink_addr, gate_complexity, external_dep_count, basic_blocks_to_sink):
+        bb = max(1, basic_blocks_to_sink)
+        return GateScore(
+            gate_addr=gate_addr,
+            sink_addr=sink_addr,
+            gate_complexity=gate_complexity,
+            external_dep_count=external_dep_count,
+            basic_blocks_to_sink=bb,
+            score=(gate_complexity * external_dep_count) / bb,
+        )
+
+
+class _StubCharacterization:
+    def __init__(self, gate_kind="env", bypass_difficulty="trivial", payload_class="shell-exec"):
+        self.gate_kind = gate_kind
+        self.external_deps = ["getenv"]
+        self.bypass_difficulty = bypass_difficulty
+        self.payload_class = payload_class
+        self.why = "stub-explanation"
+        self.model = "stub-model"
+
+
+class _StubCharacterizer:
+    def __init__(self, response=None, raise_on_addrs=None):
+        self.response = response or _StubCharacterization()
+        self.raise_on_addrs = set(raise_on_addrs or [])
+        self.calls = 0
+
+    def characterize(self, gate_slice):
+        self.calls += 1
+        if gate_slice.gate_addr in self.raise_on_addrs:
+            raise RuntimeError(f"simulated char failure at {hex(gate_slice.gate_addr)}")
+        return self.response
+
+
+# --------------------------------------------------------------------- #
+# tests
+# --------------------------------------------------------------------- #
+def _logic_traps(*specs):
+    """Helper: build a logic_traps list from ``(addr, score)`` tuples."""
+    return [(addr, {"score": score}) for addr, score in specs]
+
+
+class TestCharacterizeGatesEmptyInputs:
+    def test_no_traps_returns_empty(self):
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=[], sink_addrs=[0x402000],
+            slicer=_StubSlicer(), scorer=_StubScorer({}),
+        )
+        assert out == []
+
+    def test_no_sinks_returns_empty(self):
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 5)),
+            sink_addrs=[],
+            slicer=_StubSlicer(), scorer=_StubScorer({}),
+        )
+        assert out == []
+
+
+class TestNearestSinkSelection:
+    def test_picks_closest_sink_for_each_trap(self):
+        # Two sinks at addresses A and B; trap is 2 blocks from A, 8 from B.
+        trap_addr = 0x401000
+        sink_a = 0x402000
+        sink_b = 0x403000
+        scorer = _StubScorer({(trap_addr, sink_a): 2, (trap_addr, sink_b): 8})
+        slicer = _StubSlicer(external_calls=[_StubExternalCall("getenv")])
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((trap_addr, 6)),
+            sink_addrs=[sink_a, sink_b],
+            slicer=slicer, scorer=scorer,
+        )
+        assert len(out) == 1
+        assert out[0]["sink_addr"] == hex(sink_a)
+        # slicer received the chosen pair
+        assert slicer.calls == [(trap_addr, sink_a)]
+
+
+class TestEntryShape:
+    def test_keys_present_and_scores_computed(self):
+        slicer = _StubSlicer(external_calls=[
+            _StubExternalCall("getenv"),
+            _StubExternalCall("strcmp"),
+        ])
+        scorer = _StubScorer({(0x401000, 0x402000): 4})
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 6)),
+            sink_addrs=[0x402000],
+            slicer=slicer, scorer=scorer,
+        )
+        assert len(out) == 1
+        entry = out[0]
+        assert entry["gate_addr"] == hex(0x401000)
+        assert entry["sink_addr"] == hex(0x402000)
+        assert entry["complexity"] == 6
+        assert entry["external_deps"] == ["getenv", "strcmp"]
+        assert entry["distance_to_sink"] == 4
+        # (6 * 2) / 4 = 3.0
+        assert entry["score"] == pytest.approx(3.0)
+        assert "characterization" not in entry  # no characterizer passed
+
+
+class TestCharacterizationOptional:
+    def test_included_when_characterizer_returns(self):
+        slicer = _StubSlicer(external_calls=[_StubExternalCall("getenv")])
+        scorer = _StubScorer({(0x401000, 0x402000): 2})
+        ch = _StubCharacterizer(_StubCharacterization(gate_kind="env", bypass_difficulty="env-controllable"))
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 4)),
+            sink_addrs=[0x402000],
+            slicer=slicer, scorer=scorer, characterizer=ch,
+        )
+        assert ch.calls == 1
+        assert out[0]["characterization"]["gate_kind"] == "env"
+        assert out[0]["characterization"]["bypass_difficulty"] == "env-controllable"
+
+    def test_error_record_when_characterizer_raises(self):
+        slicer = _StubSlicer()
+        scorer = _StubScorer({(0x401000, 0x402000): 2})
+        ch = _StubCharacterizer(raise_on_addrs=[0x401000])
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 4)),
+            sink_addrs=[0x402000],
+            slicer=slicer, scorer=scorer, characterizer=ch,
+        )
+        assert "error" in out[0]["characterization"]
+        # entry still emitted; only the characterization is replaced with the error
+        assert out[0]["gate_addr"] == hex(0x401000)
+
+
+class TestSliceFailureSkipsGate:
+    def test_failed_slice_drops_that_gate(self):
+        slicer = _StubSlicer(raise_on_addrs=[0x401000])
+        scorer = _StubScorer({(0x402000, 0x402100): 3})
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 6), (0x402000, 8)),
+            sink_addrs=[0x402100],
+            slicer=slicer, scorer=scorer,
+        )
+        # First trap fails -> only the second survives
+        assert len(out) == 1
+        assert out[0]["gate_addr"] == hex(0x402000)
+
+
+class TestSortingByScore:
+    def test_highest_score_first(self):
+        # Two traps; second has higher external-dep count and is closer.
+        slicer_a = _StubSlicer(external_calls=[_StubExternalCall("getenv")])
+        # We can't easily pass two different slicers, so build a richer
+        # stub that returns different external_calls per gate.
+        class _MultiSlicer:
+            def slice_gate(self, proj, gate_addr, sink_addr):
+                if gate_addr == 0x401000:
+                    return _StubGateSlice(gate_addr=gate_addr, external_calls=[_StubExternalCall("a")])
+                return _StubGateSlice(
+                    gate_addr=gate_addr,
+                    external_calls=[_StubExternalCall("a"), _StubExternalCall("b"), _StubExternalCall("c")],
+                )
+
+        scorer = _StubScorer({
+            (0x401000, 0x403000): 5,
+            (0x402000, 0x403000): 2,
+        })
+        out = characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 4), (0x402000, 6)),
+            sink_addrs=[0x403000],
+            slicer=_MultiSlicer(), scorer=scorer,
+        )
+        assert len(out) == 2
+        # Second gate: (6 * 3) / 2 = 9.0  > first: (4 * 1) / 5 = 0.8
+        assert out[0]["gate_addr"] == hex(0x402000)
+        assert out[1]["gate_addr"] == hex(0x401000)
+
+
+class TestOnErrorCallback:
+    def test_invoked_on_slice_failure(self):
+        seen = []
+        slicer = _StubSlicer(raise_on_addrs=[0x401000])
+        scorer = _StubScorer({(0x401000, 0x402000): 3})
+        characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 4)),
+            sink_addrs=[0x402000],
+            slicer=slicer, scorer=scorer,
+            on_error=lambda addr, msg: seen.append((addr, msg)),
+        )
+        assert len(seen) == 1
+        assert seen[0][0] == 0x401000
+        assert "slice" in seen[0][1]
+
+    def test_invoked_on_characterizer_failure(self):
+        seen = []
+        slicer = _StubSlicer()
+        scorer = _StubScorer({(0x401000, 0x402000): 3})
+        ch = _StubCharacterizer(raise_on_addrs=[0x401000])
+        characterize_gates(
+            proj=None, cfg=None,
+            logic_traps=_logic_traps((0x401000, 4)),
+            sink_addrs=[0x402000],
+            slicer=slicer, scorer=scorer, characterizer=ch,
+            on_error=lambda addr, msg: seen.append((addr, msg)),
+        )
+        assert len(seen) == 1
+        assert "characterize" in seen[0][1]

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,228 @@
+"""Unit tests for the bench reporter."""
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+BENCH_REPORT = REPO_ROOT / "bench" / "report.py"
+
+
+@pytest.fixture(scope="module")
+def report_module():
+    """Import ``bench/report.py`` without invoking main()."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("bench_report", BENCH_REPORT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["bench_report"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(category, sample_id, ground_truth=None, gates=None, errored=False):
+    """Build one entry in the ``runs`` list of bench_results.json."""
+    result = {"binary_path": f"corpus/{category}/{sample_id}", "gates": gates or []}
+    if errored:
+        result = {"error": "boom"}
+    return {
+        "id": sample_id,
+        "category": category,
+        "ground_truth": ground_truth,
+        "result": result,
+    }
+
+
+def _gate(score=1.0, characterization=None):
+    g = {"gate_addr": "0x401000", "sink_addr": "0x402000", "score": score}
+    if characterization is not None:
+        g["characterization"] = characterization
+    return g
+
+
+class TestEmptyInput:
+    def test_no_runs(self, report_module):
+        summary = report_module.summarize([])
+        assert summary["overall"]["samples_total"] == 0
+        assert summary["by_category"] == {}
+
+
+class TestSampleCounting:
+    def test_counts_per_category(self, report_module):
+        runs = [
+            _run("synthetic", "a"),
+            _run("synthetic", "b"),
+            _run("xz", "c"),
+        ]
+        summary = report_module.summarize(runs)
+        assert summary["by_category"]["synthetic"]["samples_total"] == 2
+        assert summary["by_category"]["xz"]["samples_total"] == 1
+        assert summary["overall"]["samples_total"] == 3
+
+    def test_errored_samples_counted_separately(self, report_module):
+        runs = [_run("synthetic", "a", errored=True), _run("synthetic", "b")]
+        summary = report_module.summarize(runs)
+        assert summary["by_category"]["synthetic"]["samples_errored"] == 1
+        assert summary["by_category"]["synthetic"]["samples_total"] == 2
+
+
+class TestRecall:
+    def test_recall_payload_sample_with_gates(self, report_module):
+        runs = [
+            _run("synthetic", "good", ground_truth={"has_payload": True}, gates=[_gate(score=5.0)]),
+        ]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["synthetic"]
+        assert cat["positive_samples"] == 1
+        assert cat["positive_samples_recalled"] == 1
+
+    def test_recall_payload_sample_with_no_gates(self, report_module):
+        runs = [
+            _run("synthetic", "missed", ground_truth={"has_payload": True}, gates=[]),
+        ]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["synthetic"]
+        assert cat["positive_samples"] == 1
+        assert cat["positive_samples_recalled"] == 0
+
+
+class TestFalsePositives:
+    def test_fp_above_upper_bound(self, report_module):
+        # Upper bound is 1; we flagged 3 -> 2 excess flags.
+        runs = [_run("negatives", "ls",
+                     ground_truth={"has_payload": False, "expected_gates_flagged_upper_bound": 1},
+                     gates=[_gate(), _gate(), _gate()])]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["negatives"]
+        assert cat["negative_samples"] == 1
+        assert cat["false_positive_samples"] == 1
+        assert cat["false_positives"] == 2
+
+    def test_no_fp_when_under_bound(self, report_module):
+        runs = [_run("negatives", "ls",
+                     ground_truth={"has_payload": False, "expected_gates_flagged_upper_bound": 3},
+                     gates=[_gate(), _gate()])]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["negatives"]
+        assert cat["false_positive_samples"] == 0
+        assert cat["false_positives"] == 0
+
+    def test_no_fp_when_under_default_bound_zero(self, report_module):
+        # No upper_bound supplied; default is 0. Zero gates -> no FP.
+        runs = [_run("negatives", "ls",
+                     ground_truth={"has_payload": False},
+                     gates=[])]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["negatives"]
+        assert cat["false_positives"] == 0
+
+
+class TestCharacterizationMatching:
+    def test_matches_when_gate_kind_in_list(self, report_module):
+        runs = [_run(
+            "synthetic", "ok",
+            ground_truth={
+                "has_payload": True,
+                "gate_kinds": ["env", "mixed"],
+                "bypass_difficulty": "env-controllable",
+                "sink_class": "shell-exec",
+            },
+            gates=[_gate(score=5.0, characterization={
+                "gate_kind": "env",
+                "bypass_difficulty": "env-controllable",
+                "payload_class": "shell-exec",
+            })],
+        )]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["synthetic"]
+        assert cat["characterization_matches"]["gate_kind"] == 1
+        assert cat["characterization_matches"]["bypass_difficulty"] == 1
+        assert cat["characterization_matches"]["sink_class"] == 1
+        # attempts increment in lockstep with the gt fields being present
+        assert cat["characterization_attempts"]["gate_kind"] == 1
+        assert cat["characterization_attempts"]["bypass_difficulty"] == 1
+        assert cat["characterization_attempts"]["sink_class"] == 1
+
+    def test_no_match_when_value_diverges(self, report_module):
+        runs = [_run(
+            "synthetic", "off",
+            ground_truth={
+                "has_payload": True,
+                "gate_kinds": ["env"],
+                "bypass_difficulty": "trivial",
+            },
+            gates=[_gate(score=5.0, characterization={
+                "gate_kind": "crypto",
+                "bypass_difficulty": "crypto-hard",
+                "payload_class": "shell-exec",
+            })],
+        )]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["synthetic"]
+        assert cat["characterization_matches"]["gate_kind"] == 0
+        assert cat["characterization_matches"]["bypass_difficulty"] == 0
+
+    def test_compares_top_ranked_gate_only(self, report_module):
+        # Only the highest-scored gate's characterization is checked
+        # (the pipeline already sorts so gates[0] is the top).
+        runs = [_run(
+            "synthetic", "mixed",
+            ground_truth={"has_payload": True, "gate_kinds": ["env"]},
+            gates=[
+                _gate(score=9.0, characterization={"gate_kind": "env"}),
+                _gate(score=0.5, characterization={"gate_kind": "crypto"}),
+            ],
+        )]
+        s = report_module.summarize(runs)
+        cat = s["by_category"]["synthetic"]
+        assert cat["characterization_matches"]["gate_kind"] == 1
+
+
+class TestOverallAggregation:
+    def test_overall_sums_categories(self, report_module):
+        runs = [
+            _run("synthetic", "a", ground_truth={"has_payload": True}, gates=[_gate()]),
+            _run("xz", "b", ground_truth={"has_payload": True}, gates=[_gate(), _gate()]),
+            _run("negatives", "c", ground_truth={"has_payload": False}, gates=[_gate()]),
+        ]
+        s = report_module.summarize(runs)
+        assert s["overall"]["samples_total"] == 3
+        assert s["overall"]["gates_flagged"] == 4
+        assert s["overall"]["positive_samples"] == 2
+        assert s["overall"]["positive_samples_recalled"] == 2
+        assert s["overall"]["negative_samples"] == 1
+
+
+class TestRendering:
+    def test_text_renders_summary(self, report_module):
+        runs = [
+            _run("synthetic", "a", ground_truth={"has_payload": True}, gates=[_gate(score=5.0)]),
+        ]
+        s = report_module.summarize(runs)
+        text = report_module.render_text(s)
+        assert "[synthetic]" in text
+        assert "[overall]" in text
+        assert "recall" in text
+
+
+class TestEndToEndJson:
+    def test_round_trip_via_main(self, report_module, tmp_path, capsys):
+        results_path = tmp_path / "results.json"
+        summary_path = tmp_path / "summary.json"
+        data = {
+            "runs": [
+                _run("synthetic", "a", ground_truth={"has_payload": True}, gates=[_gate()]),
+            ],
+        }
+        results_path.write_text(json.dumps(data))
+        rc = report_module.main(["--results", str(results_path), "--json", str(summary_path)])
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "samples processed" in out
+        summary = json.loads(summary_path.read_text())
+        assert summary["overall"]["samples_total"] == 1
+
+    def test_missing_results_returns_nonzero(self, report_module, tmp_path, capsys):
+        rc = report_module.main(["--results", str(tmp_path / "nope.json")])
+        assert rc == 1


### PR DESCRIPTION
New Model/pipeline.py glues locator -> slicer -> characterizer -> scorer into the gate-centric output documented in the README; the orchestrator's analyze_enhanced now calls it and includes a gates array in the returned dict. New bench/report.py aggregates output/bench_results.json into per-category and overall recall, false-positive rate, and characterization-match metrics. Corpus manifests for xz, gadget-chains, and negatives are populated (XZ predicate set, 3 Java gadget-chain placeholders, 10 standard Linux binaries with calibrated FP upper bounds). test_pipeline.py and test_report.py add 28 tests covering both new modules.